### PR TITLE
chore: rename application to V.01

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -10,8 +10,8 @@ import plotly.express as px
 import streamlit as st
 
 # ------------- App Config -------------
-st.set_page_config(page_title="BoQ Bid Studio", layout="wide")
-st.title("🏗️ BoQ Bid Studio")
+st.set_page_config(page_title="BoQ Bid Studio V.01", layout="wide")
+st.title("🏗️ BoQ Bid Studio V.01")
 st.caption("Jedna aplikace pro nahrání, mapování, porovnání nabídek a vizualizace — bez exportů do Excelu.")
 
 # ------------- Helpers -------------


### PR DESCRIPTION
## Summary
- rename app title and page configuration to BoQ Bid Studio V.01 to reflect fix

## Testing
- `python -m py_compile boq_bid_studio.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1c45020c83228681442c12e5c68d