### PR TITLE
feat: separate sheet selection for comparison and overview

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -445,31 +445,56 @@ if not master_file:
     st.info("➡️ Nahraj Master BoQ v levém panelu.")
     st.stop()
 
-# Read master
-master_wb = read_workbook(master_file)
+# Determine sheet names without loading all sheets
+master_xl = pd.ExcelFile(master_file)
+all_sheets = master_xl.sheet_names
 
-# Confirm sheet selection (default all master sheets)
-all_sheets = list(master_wb.sheets.keys())
-selected_sheets = st.sidebar.multiselect("Které listy zahrnout", all_sheets, default=all_sheets)
+# User selections for comparison and overview
+compare_sheets = st.sidebar.multiselect("Listy pro porovnání", all_sheets, default=all_sheets)
+default_overview = "Přehled_dílčí kapitoly" if "Přehled_dílčí kapitoly" in all_sheets else (all_sheets[0] if all_sheets else "")
+overview_sheet = st.sidebar.selectbox("List pro přehled", all_sheets, index=all_sheets.index(default_overview) if default_overview in all_sheets else 0)
 
-# Sheet used for overview comparison
-default_overview = "Přehled_dílčí kapitoly" if "Přehled_dílčí kapitoly" in selected_sheets else (selected_sheets[0] if selected_sheets else "")
-overview_sheet = st.sidebar.selectbox("List pro sumarizační porovnání", selected_sheets, index=selected_sheets.index(default_overview) if default_overview in selected_sheets else 0)
+# Read master only for selected comparison sheets
+master_file.seek(0)
+master_wb = read_workbook(master_file, limit_sheets=compare_sheets)
 
-# Filter master to selected sheets
-master_wb.sheets = {s: master_wb.sheets[s] for s in selected_sheets}
+# If overview sheet not among comparison sheets, load separately
+if overview_sheet in compare_sheets:
+    master_overview_wb = WorkbookData(name=master_wb.name, sheets={overview_sheet: master_wb.sheets[overview_sheet]})
+else:
+    master_file.seek(0)
+    master_overview_wb = read_workbook(master_file, limit_sheets=[overview_sheet])
 
-# Read bids
+# Read bids for comparison sheets and overview sheet separately
 bids_dict: Dict[str, WorkbookData] = {}
+bids_overview_dict: Dict[str, WorkbookData] = {}
 if bid_files:
     if len(bid_files) > 7:
         st.sidebar.warning("Zpracuje se pouze prvních 7 souborů.")
         bid_files = bid_files[:7]
     for i, f in enumerate(bid_files, start=1):
         name = getattr(f, "name", f"Bid{i}")
-        wb = read_workbook(f, limit_sheets=selected_sheets)
-        apply_master_mapping(master_wb, wb)
-        bids_dict[name] = wb
+        f.seek(0)
+        wb_comp = read_workbook(f, limit_sheets=compare_sheets)
+        apply_master_mapping(master_wb, wb_comp)
+        bids_dict[name] = wb_comp
+
+        if overview_sheet in compare_sheets:
+            wb_over = WorkbookData(name=wb_comp.name, sheets={overview_sheet: wb_comp.sheets.get(overview_sheet, {})})
+        else:
+            f.seek(0)
+            wb_over = read_workbook(f, limit_sheets=[overview_sheet])
+            apply_master_mapping(master_overview_wb, wb_over)
+        bids_overview_dict[name] = wb_over
+
+
+# Pre-compute comparison results for reuse in tabs
+compare_results: Dict[str, pd.DataFrame] = {}
+overview_results: Dict[str, pd.DataFrame] = {}
+if bids_dict:
+    compare_results = compare(master_wb, bids_dict, join_mode="auto")
+if bids_overview_dict:
+    overview_results = compare(master_overview_wb, bids_overview_dict, join_mode="auto")
 
 # ------------- Tabs -------------
 tab_data, tab_compare, tab_summary, tab_overview, tab_dashboard, tab_qa = st.tabs([
@@ -483,17 +508,24 @@ tab_data, tab_compare, tab_summary, tab_overview, tab_dashboard, tab_qa = st.tab
 
 with tab_data:
     mapping_ui("Master", master_wb)
+    if overview_sheet not in compare_sheets:
+        with st.expander("Mapování — Master přehled", expanded=False):
+            mapping_ui("Master overview", master_overview_wb)
     if bids_dict:
         for sup_name, wb in bids_dict.items():
             with st.expander(f"Mapování — {sup_name}", expanded=False):
                 mapping_ui(sup_name, wb)
+        if overview_sheet not in compare_sheets:
+            for sup_name, wb in bids_overview_dict.items():
+                with st.expander(f"Mapování přehled — {sup_name}", expanded=False):
+                    mapping_ui(f"{sup_name} overview", wb)
     st.success("Mapování připraveno. Přepni na záložku **Porovnání**.")
 
 with tab_compare:
     if not bids_dict:
         st.info("Nahraj alespoň jednu nabídku dodavatele v levém panelu.")
     else:
-        results = compare(master_wb, bids_dict, join_mode="auto")
+        results = compare_results
         # main per-sheet tables
         for sheet, df in results.items():
             st.subheader(f"List: {sheet}")
@@ -522,7 +554,7 @@ with tab_summary:
     if not bids_dict:
         st.info("Nahraj alespoň jednu nabídku dodavatele v levém panelu.")
     else:
-        results = compare(master_wb, bids_dict, join_mode="auto")
+        results = compare_results
         summary_df = summarize(results)
         if not summary_df.empty:
             st.markdown("### 📌 Souhrn po listech")
@@ -548,10 +580,10 @@ with tab_summary:
                     pass
 
 with tab_overview:
-    if not bids_dict:
+    if not bids_overview_dict:
         st.info("Nahraj alespoň jednu nabídku dodavatele v levém panelu.")
     else:
-        results = compare(master_wb, bids_dict, join_mode="auto")
+        results = overview_results
         sections_df, indirect_df, added_df = overview_comparison(results, overview_sheet)
         if sections_df.empty and indirect_df.empty and added_df.empty:
             st.info(f"List '{overview_sheet}' neobsahuje data pro porovnání.")
@@ -571,7 +603,7 @@ with tab_dashboard:
     if not bids_dict:
         st.info("Nejdřív nahraj nabídky.")
     else:
-        results = compare(master_wb, bids_dict, join_mode="auto")
+        results = compare_results
         # Choose a sheet for detailed variance chart
         sheet_choices = list(results.keys())
         if sheet_choices:


### PR DESCRIPTION
## Summary
- allow choosing comparison sheets independently from overview sheet
- load workbooks only for selected comparison sheets
- compute comparison and overview results on dedicated sheet sets

## Testing
- `python -m py_compile boq_bid_studio.py`


------
https://chatgpt.com/codex/tasks/task_e_68c13565215c83229d461e577fce3ff5