### PR TITLE
Precompute overview results and add bid-loading test

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -542,6 +542,17 @@ if bid_files:
 compare_results: Dict[str, pd.DataFrame] = {}
 if bids_dict:
     compare_results = compare(master_wb, bids_dict, join_mode="auto")
+
+# Pre-compute overview results to avoid repeated work in tabs
+overview_results: Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame] = (
+    pd.DataFrame(),
+    pd.DataFrame(),
+    pd.DataFrame(),
+)
+if bids_overview_dict:
+    overview_results = overview_comparison(
+        master_overview_wb, bids_overview_dict, overview_sheet
+    )
 # ------------- Tabs -------------
 tab_data, tab_compare, tab_summary, tab_overview, tab_dashboard, tab_qa = st.tabs([
     "📑 Mapování",
@@ -631,9 +642,7 @@ with tab_overview:
     if not bids_overview_dict:
         st.info("Nahraj alespoň jednu nabídku dodavatele v levém panelu.")
     else:
-        sections_df, indirect_df, added_df = overview_comparison(
-            master_overview_wb, bids_overview_dict, overview_sheet
-        )
+        sections_df, indirect_df, added_df = overview_results
         if sections_df.empty and indirect_df.empty and added_df.empty:
             st.info(f"List '{overview_sheet}' neobsahuje data pro porovnání.")
         else:

--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -1,0 +1,64 @@
+import io
+import os
+import types
+from pathlib import Path
+import pandas as pd
+
+# Load only helper functions from boq_bid_studio without running Streamlit app
+module_code = (
+    Path(__file__).resolve().parent.parent / "boq_bid_studio.py"
+).read_text().split("# ------------- Sidebar Inputs -------------")[0]
+module = types.ModuleType("boq_bid_helpers")
+exec(module_code, module.__dict__)
+module.try_autodetect_mapping = module.try_autodetect_mapping.__wrapped__
+module.build_normalized_table = module.build_normalized_table.__wrapped__
+read_workbook = module.read_workbook.__wrapped__
+apply_master_mapping = module.apply_master_mapping
+compare = module.compare
+
+
+def make_workbook(df: pd.DataFrame) -> io.BytesIO:
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False, sheet_name="Sheet1")
+    buffer.seek(0)
+    buffer.name = "test.xlsx"
+    return buffer
+
+
+def test_multiple_bid_loading() -> None:
+    master_df = pd.DataFrame({
+        "code": ["A"],
+        "description": ["Item"],
+        "unit": ["m"],
+        "quantity": [1],
+        "unit_price": [10],
+        "total_price": [10],
+    })
+    bid_df = pd.DataFrame({
+        "code": ["A"],
+        "description": ["Item"],
+        "unit": ["m"],
+        "quantity": [1],
+        "unit_price": [12],
+        "total_price": [12],
+    })
+
+    master_file = make_workbook(master_df)
+    bid1 = make_workbook(bid_df)
+    bid2 = make_workbook(bid_df)
+
+    master_wb = read_workbook(master_file, limit_sheets=["Sheet1"])
+
+    bids = {}
+    for i, f in enumerate([bid1, bid2], start=1):
+        f.seek(0)
+        wb = read_workbook(f, limit_sheets=["Sheet1"])
+        apply_master_mapping(master_wb, wb)
+        bids[f"Bid{i}"] = wb
+
+    results = compare(master_wb, bids)
+    assert "Sheet1" in results
+    df = results["Sheet1"]
+    assert not df.empty
+    assert df.shape[0] == 1


### PR DESCRIPTION
## Summary
- Cache overview comparison alongside main comparison results
- Use cached overview data in overview tab to prevent redundant work
- Add unit test exercising bid-loading loop with multiple bids

## Testing
- `flake8 --select=E9,F63,F7,F82 boq_bid_studio.py tests/test_bid_loading.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1687e264c8322831191761f8c52e0