### PR TITLE
Fix Streamlit cache serialization error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 openpyxl
 plotly
 numpy
+cloudpickle


### PR DESCRIPTION
## Summary
- Add missing `cloudpickle` dependency to ensure Streamlit can serialize cached workbook objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18894a3f88322ba0d5d3482ecd2ee