### PR TITLE
Fix Streamlit cache serialization for workbook data

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1,13 +1,13 @@
 
 import re
 import json
-from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import plotly.express as px
 import streamlit as st
+from workbook import WorkbookData
 
 # ------------- App Config -------------
 st.set_page_config(page_title="BoQ Bid Studio V.04", layout="wide")
@@ -130,11 +130,6 @@ def show_df(df: pd.DataFrame) -> None:
         st.dataframe(df)
     else:
         st.dataframe(df.style.format({col: format_number for col in numeric_cols}))
-
-@dataclass
-class WorkbookData:
-    name: str
-    sheets: Dict[str, Dict] = field(default_factory=dict)  # sheet -> {"raw": df_raw, "mapping": dict, "header_row": int, "table": df_norm}
 
 @st.cache_data
 def read_workbook(upload, limit_sheets: Optional[List[str]] = None) -> WorkbookData:

--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -1,13 +1,14 @@
 import io
 import os
+import sys
 import types
 from pathlib import Path
 import pandas as pd
 
 # Load only helper functions from boq_bid_studio without running Streamlit app
-module_code = (
-    Path(__file__).resolve().parent.parent / "boq_bid_studio.py"
-).read_text().split("# ------------- Sidebar Inputs -------------")[0]
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+module_code = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
 module = types.ModuleType("boq_bid_helpers")
 exec(module_code, module.__dict__)
 module.try_autodetect_mapping = module.try_autodetect_mapping.__wrapped__

--- a/workbook.py
+++ b/workbook.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass, field
+from typing import Dict
+
+@dataclass
+class WorkbookData:
+    """Container for parsed workbook data."""
+    name: str
+    sheets: Dict[str, Dict] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- Move `WorkbookData` dataclass into new `workbook` module so Streamlit can serialize cached data
- Import `WorkbookData` from new module and remove inline definition to avoid caching errors
- Adjust tests to load helper module from project root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18ab3df0883229d2585c9222675aa