### PR TITLE
Add summary price column and improve recap mapping

### DIFF
--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -194,3 +194,18 @@ def test_summary_type_and_dedup() -> None:
     # duplicate summary row should be removed
     assert out.shape[0] == 4
     assert out["summary_type"].tolist() == ["", "", "section", "grand"]
+
+
+def test_summary_price_column() -> None:
+    df = pd.DataFrame(
+        {
+            "code": ["1", ""],
+            "description": ["item", "součet"],
+            "quantity": ["1", ""],
+            "total_price": ["10", "10"],
+        }
+    )
+    mapping = {"code": 0, "description": 1, "quantity": 2, "total_price": 3}
+    out = module.build_normalized_table(df, mapping)
+    assert pd.isna(out.loc[0, "summary_price"])
+    assert out.loc[1, "summary_price"] == 10


### PR DESCRIPTION
## Summary
- add `summary_price` field in normalized tables to retain subtotal values
- allow auto-mapping of "množství dle dodavatele" for supplier quantity
- include section numbers in recap totals and sort them naturally

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8dbf3dc8322ad6c59920717fb8f