### PR TITLE
Handle missing unit prices by falling back to total price

### DIFF
--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -115,6 +115,30 @@ def test_total_diff_and_summary_detection() -> None:
     assert validate_totals(out) == 0
 
 
+def test_calc_total_falls_back_to_total_price_when_unit_missing() -> None:
+    df = pd.DataFrame(
+        {
+            "code": ["1"],
+            "description": ["item"],
+            "unit": ["m"],
+            "quantity": ["2"],
+            "total_price": ["50"],
+        }
+    )
+    mapping = {
+        "code": 0,
+        "description": 1,
+        "unit": 2,
+        "quantity": 3,
+        "total_price": 4,
+    }
+    out = module.build_normalized_table(df, mapping)
+    assert out.loc[0, "calc_total"] == 50
+    assert out.loc[0, "total_diff"] == 0
+    # calc_total should contribute to overall sums
+    assert out["calc_total"].sum() == 50
+
+
 def test_ignore_rows_without_description() -> None:
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Fall back to existing `total_price` when unit prices are missing to ensure items without unit pricing still contribute to totals
- Test that `calc_total` uses `total_price` if unit prices are absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bbe3284c83228ec036389de77bdc