### PR TITLE
Narrow code header hints

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -24,7 +24,6 @@ HEADER_HINTS = {
         "č",
         "číslo položky",
         "cislo polozky",
-        "id",
         "kód",
         "kod",
         "regex:^pol\\.?$",
@@ -33,7 +32,17 @@ HEADER_HINTS = {
     "unit": ["unit", "jm", "mj", "jednotka", "uom", "měrná jednotka", "merna jednotka"],
     "quantity": ["quantity", "qty", "množství", "mnozstvi", "q"],
     # optional extras commonly seen
-    "item_id": ["item id", "itemid", "id položky", "id polozky", "kod", "kód", "číslo položky", "cislo polozky"],
+    "item_id": [
+        "item id",
+        "itemid",
+        "id položky",
+        "id polozky",
+        "kod",
+        "kód",
+        "číslo položky",
+        "cislo polozky",
+        "regex:^id$",
+    ],
     # extended optional columns for richer comparisons
     "quantity_supplier": [
         "množství dodavatel",


### PR DESCRIPTION
## Summary
- avoid mapping bidder comments to code by removing generic id hint
- allow strict `id` mapping only for item identifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7ce0dbc888322a68c150b28cdfbf8