### PR TITLE
Stop mutating exchange rate widgets after render

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -110,8 +110,6 @@ def update_exchange_rate_shared(value: Any) -> float:
             st.session_state.get(EXCHANGE_RATE_STATE_KEY, DEFAULT_EXCHANGE_RATE)
         )
     st.session_state[EXCHANGE_RATE_STATE_KEY] = exchange_rate
-    for widget_key in EXCHANGE_RATE_WIDGET_KEYS.values():
-        st.session_state[widget_key] = exchange_rate
     return exchange_rate
 
 def normalize_col(c):


### PR DESCRIPTION
## Summary
- avoid updating exchange rate widget state from the shared updater to comply with Streamlit's session restrictions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbd40deb248322b03ec84e706b4cc6