### PR TITLE
Fix grouped sections item order fallback

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1017,7 +1017,11 @@ def prepare_grouped_sections(
         working["source_order"] = np.arange(len(working))
     working = working.reset_index(drop=True)
     working["item_order"] = pd.to_numeric(working["source_order"], errors="coerce")
-    working["item_order"] = working["item_order"].fillna(np.arange(len(working)))
+    if working["item_order"].isna().any():
+        fallback_order = pd.Series(
+            np.arange(len(working), dtype=float), index=working.index
+        )
+        working["item_order"] = working["item_order"].fillna(fallback_order)
     if "auto_group_key" not in working.columns:
         working["auto_group_key"] = working["code"]
     if "auto_group_label" not in working.columns:


### PR DESCRIPTION
## Summary
- replace the NumPy fallback array in `prepare_grouped_sections` with an index-aligned Series
- prevent pandas `fillna` from raising a `TypeError` when building the grouped recap overview

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbda6e40d0832298ec8eaeb1ed8036