### PR TITLE
Implement recap export, storage, and chart fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ openpyxl
 plotly
 numpy
 cloudpickle
+reportlab
+kaleido

--- a/tests/test_offer_storage.py
+++ b/tests/test_offer_storage.py
@@ -1,0 +1,47 @@
+import io
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+module = types.ModuleType("boq_bid_helpers_storage")
+exec(MODULE_CODE, module.__dict__)
+
+OfferStorage = module.OfferStorage
+
+
+def test_offer_storage_save_and_load_master(tmp_path) -> None:
+    storage = OfferStorage(base_dir=tmp_path)
+    payload = io.BytesIO(b"master data")
+    payload.name = "master.xlsx"
+
+    storage.save_master(payload)
+
+    stored_entries = storage.list_master()
+    assert stored_entries and stored_entries[0]["name"] == "master.xlsx"
+
+    loaded = storage.load_master("master.xlsx")
+    assert loaded.read() == b"master data"
+
+
+def test_offer_storage_overwrite_and_delete_bid(tmp_path) -> None:
+    storage = OfferStorage(base_dir=tmp_path)
+    first = io.BytesIO(b"first")
+    first.name = "bid.xlsx"
+    storage.save_bid(first)
+
+    updated = io.BytesIO(b"updated")
+    updated.name = "bid.xlsx"
+    storage.save_bid(updated)
+
+    loaded = storage.load_bid("bid.xlsx")
+    assert loaded.read() == b"updated"
+
+    assert storage.delete_bid("bid.xlsx") is True
+    assert storage.list_bids() == []
+    with pytest.raises(FileNotFoundError):
+        storage.load_bid("bid.xlsx")

--- a/tests/test_recap_chart.py
+++ b/tests/test_recap_chart.py
@@ -1,0 +1,50 @@
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+module = types.ModuleType("boq_bid_helpers_recap")
+exec(MODULE_CODE, module.__dict__)
+
+build_recap_chart_data = module.build_recap_chart_data
+
+
+def test_build_recap_chart_data_calculates_percentages() -> None:
+    value_cols = ["Master total", "Bid1 total", "Bid2 total"]
+    net_series = pd.Series({
+        "Master total": 100.0,
+        "Bid1 total": 110.0,
+        "Bid2 total": 90.0,
+    })
+
+    chart_df = build_recap_chart_data(value_cols, net_series)
+
+    master_row = chart_df.loc[chart_df["Dodavatel"] == "Master"].iloc[0]
+    bid1_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
+    bid2_row = chart_df.loc[chart_df["Dodavatel"] == "Bid2"].iloc[0]
+
+    assert master_row["Odchylka vs Master (%)"] == pytest.approx(0.0)
+    assert bid1_row["Odchylka vs Master (%)"] == pytest.approx(10.0)
+    assert bid2_row["Odchylka vs Master (%)"] == pytest.approx(-10.0)
+    assert master_row["Popisek"] == "+0,00 %"
+    assert bid1_row["Popisek"] == "+10,00 %"
+    assert bid2_row["Popisek"] == "-10,00 %"
+
+
+def test_build_recap_chart_data_handles_missing_master() -> None:
+    value_cols = ["Master total", "Bid1 total"]
+    net_series = pd.Series({
+        "Master total": 0.0,
+        "Bid1 total": 120.0,
+    })
+
+    chart_df = build_recap_chart_data(value_cols, net_series)
+    bid_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
+
+    assert pd.isna(bid_row["Odchylka vs Master (%)"])
+    assert bid_row["Popisek"] == "–"


### PR DESCRIPTION
## Summary
- add an OfferStorage helper and sidebar controls so uploaded Master and bid workbooks persist across sessions and can be replaced or deleted
- improve the recap tab by fixing percent deltas, generating a PDF export, and wiring the new helpers into the workflow
- bump the default exchange rate to 25.51 and declare the PDF/image dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d1506860ac8322a8e24524622a8310