### PR TITLE
Fix TypeError when aggregating source order values

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -974,7 +974,9 @@ def _aggregate_table_for_engine(table: pd.DataFrame, *, supplier: bool = False) 
     aggregated.drop(columns=["weighted_price"], inplace=True)
     aggregated["quantity"] = aggregated["quantity"].fillna(0.0)
     aggregated["unit_price"] = aggregated["unit_price"].replace({np.inf: np.nan})
-    aggregated["source_order"] = aggregated["source_order"].fillna(np.arange(len(aggregated), dtype=float))
+    if aggregated["source_order"].isna().any():
+        filler = pd.Series(np.arange(len(aggregated), dtype=float), index=aggregated.index)
+        aggregated["source_order"] = aggregated["source_order"].combine_first(filler)
 
     return aggregated
 


### PR DESCRIPTION
## Summary
- replace use of `fillna` with a numpy array during aggregation with `combine_first`
- ensure source order defaults are generated without triggering pandas TypeError

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a0bed0588322bb3bf83633c8dd9d