### PR TITLE
Update recap tab tables, chart, and PDF layout

### DIFF
--- a/tests/test_recap_chart.py
+++ b/tests/test_recap_chart.py
@@ -3,7 +3,6 @@ import types
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
@@ -15,7 +14,7 @@ build_recap_chart_data = module.build_recap_chart_data
 generate_recap_pdf = module.generate_recap_pdf
 
 
-def test_build_recap_chart_data_calculates_percentages() -> None:
+def test_build_recap_chart_data_formats_currency_labels() -> None:
     value_cols = ["Master total", "Bid1 total", "Bid2 total"]
     net_series = pd.Series({
         "Master total": 100.0,
@@ -23,31 +22,25 @@ def test_build_recap_chart_data_calculates_percentages() -> None:
         "Bid2 total": 90.0,
     })
 
-    chart_df = build_recap_chart_data(value_cols, net_series)
+    chart_df = build_recap_chart_data(value_cols, net_series, currency_label="CZK")
 
     master_row = chart_df.loc[chart_df["Dodavatel"] == "Master"].iloc[0]
     bid1_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
     bid2_row = chart_df.loc[chart_df["Dodavatel"] == "Bid2"].iloc[0]
 
-    assert master_row["Odchylka vs Master (%)"] == pytest.approx(0.0)
-    assert bid1_row["Odchylka vs Master (%)"] == pytest.approx(10.0)
-    assert bid2_row["Odchylka vs Master (%)"] == pytest.approx(-10.0)
-    assert master_row["Popisek"] == "+0,00 %"
-    assert bid1_row["Popisek"] == "+10,00 %"
-    assert bid2_row["Popisek"] == "-10,00 %"
+    assert "Odchylka vs Master (%)" not in chart_df.columns
+    assert master_row["Popisek"] == "100,00 CZK"
+    assert bid1_row["Popisek"] == "110,00 CZK"
+    assert bid2_row["Popisek"] == "90,00 CZK"
 
 
-def test_build_recap_chart_data_handles_missing_master() -> None:
+def test_build_recap_chart_data_handles_missing_values() -> None:
     value_cols = ["Master total", "Bid1 total"]
-    net_series = pd.Series({
-        "Master total": 0.0,
-        "Bid1 total": 120.0,
-    })
+    net_series = pd.Series({"Master total": 0.0})
 
-    chart_df = build_recap_chart_data(value_cols, net_series)
+    chart_df = build_recap_chart_data(value_cols, net_series, currency_label="CZK")
     bid_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
 
-    assert pd.isna(bid_row["Odchylka vs Master (%)"])
     assert bid_row["Popisek"] == "–"
 
 


### PR DESCRIPTION
## Summary
- ensure recap tables include Master comparisons only for suppliers and add an editable coordination table beneath the converted summary
- replace the recap chart percent labels with currency values and adjust hover text to show the price after deductions
- improve the recap PDF layout with wrapped table cells sized for landscape pages and update chart tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d401446c088322897a6cde6e2789ef