### PR TITLE
Align supplier mapping with header names

### DIFF
--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -153,6 +153,41 @@ def test_compare_master_total_with_duplicate_supplier_rows() -> None:
     assert np.isclose(df.attrs["master_total_sum"], 100)
 
 
+def test_apply_master_mapping_aligns_by_header_name() -> None:
+    master_df = pd.DataFrame(
+        {
+            "code": ["A"],
+            "description": ["Item"],
+            "unit": ["m"],
+            "quantity": [2],
+            "total price": [100],
+        }
+    )
+    supplier_df = pd.DataFrame(
+        {
+            "description": ["Item"],
+            "code": ["A"],
+            "total price": [120],
+            "quantity": [2],
+            "unit": ["m"],
+        }
+    )
+
+    master_file = make_workbook(master_df)
+    supplier_file = make_workbook(supplier_df)
+
+    master_wb = read_workbook(master_file, limit_sheets=["Sheet1"])
+    supplier_wb = read_workbook(supplier_file, limit_sheets=["Sheet1"])
+
+    apply_master_mapping(master_wb, supplier_wb)
+
+    results = compare(master_wb, {"Bid": supplier_wb})
+    assert "Sheet1" in results
+    df = results["Sheet1"]
+    assert df.shape[0] == 1
+    assert np.isclose(df["Bid total"].iloc[0], 120)
+
+
 def test_coerce_numeric_european_formats() -> None:
     s = pd.Series(["1 234,56", "1 234", "1234", "1.234,5", "-"])
     res = module.coerce_numeric(s)


### PR DESCRIPTION
## Summary
- update supplier mapping propagation to resolve columns by normalized header names rather than raw indexes
- reuse existing supplier mapping as fallback and align header detection to keep totals intact
- add regression test to ensure supplier totals remain correct when column order differs from the master

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40a2010a083229905e28432ba32a2