### PR TITLE
Fix item chart index naming for Top položky chart

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -4816,10 +4816,10 @@ with tab_dashboard:
                 leading_supplier = item_abs.loc[item_deltas.index].idxmax(axis=1)
                 item_chart_df = (
                     item_deltas.rename("value")
+                    .rename_axis("item")
                     .to_frame()
                     .join(leading_supplier.rename("supplier"), how="left")
                     .reset_index()
-                    .rename(columns={"index": "item"})
                 )
                 try:
                     fig2 = px.bar(


### PR DESCRIPTION
## Summary
- rename the item delta Series index to "item" before resetting
- remove the unused rename step so the Top položky bar chart gets the expected columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd18aa2d4c8322bd453277e5ee2a12