### PR TITLE
Restore recap percentage deltas in recap chart

### DIFF
--- a/tests/test_recap_chart.py
+++ b/tests/test_recap_chart.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
@@ -14,7 +15,7 @@ build_recap_chart_data = module.build_recap_chart_data
 generate_recap_pdf = module.generate_recap_pdf
 
 
-def test_build_recap_chart_data_formats_currency_labels() -> None:
+def test_build_recap_chart_data_calculates_percentages() -> None:
     value_cols = ["Master total", "Bid1 total", "Bid2 total"]
     net_series = pd.Series({
         "Master total": 100.0,
@@ -28,20 +29,30 @@ def test_build_recap_chart_data_formats_currency_labels() -> None:
     bid1_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
     bid2_row = chart_df.loc[chart_df["Dodavatel"] == "Bid2"].iloc[0]
 
-    assert "Odchylka vs Master (%)" not in chart_df.columns
-    assert master_row["Popisek"] == "100,00 CZK"
-    assert bid1_row["Popisek"] == "110,00 CZK"
-    assert bid2_row["Popisek"] == "90,00 CZK"
+    assert master_row["Odchylka vs Master (%)"] == pytest.approx(0.0)
+    assert bid1_row["Odchylka vs Master (%)"] == pytest.approx(10.0)
+    assert bid2_row["Odchylka vs Master (%)"] == pytest.approx(-10.0)
+    assert master_row["Popisek"] == "+0,00 %"
+    assert bid1_row["Popisek"] == "+10,00 %"
+    assert bid2_row["Popisek"] == "-10,00 %"
+    assert master_row["Cena (text)"] == "100,00 CZK"
+    assert bid1_row["Cena (text)"] == "110,00 CZK"
+    assert bid2_row["Cena (text)"] == "90,00 CZK"
 
 
-def test_build_recap_chart_data_handles_missing_values() -> None:
+def test_build_recap_chart_data_handles_missing_master() -> None:
     value_cols = ["Master total", "Bid1 total"]
-    net_series = pd.Series({"Master total": 0.0})
+    net_series = pd.Series({
+        "Master total": 0.0,
+        "Bid1 total": 120.0,
+    })
 
     chart_df = build_recap_chart_data(value_cols, net_series, currency_label="CZK")
     bid_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
 
+    assert pd.isna(bid_row["Odchylka vs Master (%)"])
     assert bid_row["Popisek"] == "–"
+    assert bid_row["Cena (text)"] == "120,00 CZK"
 
 
 def test_generate_recap_pdf_embeds_unicode_font() -> None:


### PR DESCRIPTION
## Summary
- restore the recap chart's percent-difference calculation while keeping a textual currency label
- show both formatted prices and percent deltas in the recap bar chart tooltip
- extend recap chart tests to cover the returned columns and formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd359245a0832297fd26d12f3785d0