### PR TITLE
Show recap chart prices and adjust percent column width

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -721,8 +721,11 @@ def compute_display_column_widths(
             max_length = as_text.map(lambda x: len(str(x))).max()
         else:
             max_length = len(str(as_text))
-        header_length = len(str(col))
-        effective_len = max(int(max_length or 0), header_length)
+        header_text = str(col)
+        header_length = len(header_text)
+        effective_len = int(max_length or 0)
+        if "%" not in header_text:
+            effective_len = max(effective_len, header_length)
         width_px = max(min_width, min(max_width, (effective_len + 1) * 9))
         widths[col] = int(width_px)
     return widths
@@ -996,11 +999,14 @@ def build_recap_chart_data(
             continue
         deltas.append(((float(value) - master_val) / master_val) * 100.0)
     chart_df["Odchylka vs Master (%)"] = deltas
-    chart_df["Popisek"] = chart_df["Odchylka vs Master (%)"].apply(format_percent_label)
+    chart_df["Odchylka (text)"] = chart_df["Odchylka vs Master (%)"].apply(
+        format_percent_label
+    )
     chart_df["Cena (text)"] = [
         format_currency_label(value, currency_label)
         for value in chart_df["Cena po odečtech"]
     ]
+    chart_df["Popisek"] = chart_df["Cena (text)"]
     return chart_df
 
 
@@ -4439,12 +4445,12 @@ with tab_rekap:
                             textposition="outside",
                             texttemplate="%{text}",
                             customdata=np.column_stack(
-                                [chart_df["Cena (text)"].fillna("–")]
+                                [chart_df["Odchylka (text)"].fillna("–")]
                             ),
                             hovertemplate=(
                                 "<b>%{x}</b><br>"
-                                "Cena po odečtech: %{customdata[0]}<br>"
-                                "Odchylka vs Master: %{text}<extra></extra>"
+                                "Cena po odečtech: %{text}<br>"
+                                "Odchylka vs Master: %{customdata[0]}<extra></extra>"
                             ),
                         )
                         fig_recap.update_layout(yaxis_title=f"{base_currency}", showlegend=False)

--- a/tests/test_recap_chart.py
+++ b/tests/test_recap_chart.py
@@ -32,9 +32,12 @@ def test_build_recap_chart_data_calculates_percentages() -> None:
     assert master_row["Odchylka vs Master (%)"] == pytest.approx(0.0)
     assert bid1_row["Odchylka vs Master (%)"] == pytest.approx(10.0)
     assert bid2_row["Odchylka vs Master (%)"] == pytest.approx(-10.0)
-    assert master_row["Popisek"] == "+0,00 %"
-    assert bid1_row["Popisek"] == "+10,00 %"
-    assert bid2_row["Popisek"] == "-10,00 %"
+    assert master_row["Popisek"] == "100,00 CZK"
+    assert bid1_row["Popisek"] == "110,00 CZK"
+    assert bid2_row["Popisek"] == "90,00 CZK"
+    assert master_row["Odchylka (text)"] == "+0,00 %"
+    assert bid1_row["Odchylka (text)"] == "+10,00 %"
+    assert bid2_row["Odchylka (text)"] == "-10,00 %"
     assert master_row["Cena (text)"] == "100,00 CZK"
     assert bid1_row["Cena (text)"] == "110,00 CZK"
     assert bid2_row["Cena (text)"] == "90,00 CZK"
@@ -51,7 +54,7 @@ def test_build_recap_chart_data_handles_missing_master() -> None:
     bid_row = chart_df.loc[chart_df["Dodavatel"] == "Bid1"].iloc[0]
 
     assert pd.isna(bid_row["Odchylka vs Master (%)"])
-    assert bid_row["Popisek"] == "–"
+    assert bid_row["Popisek"] == "120,00 CZK"
     assert bid_row["Cena (text)"] == "120,00 CZK"
 
 


### PR DESCRIPTION
## Summary
- display currency values on the recap chart labels while keeping percent deviations in hover details
- size percent columns using their value lengths instead of the long header strings
- update recap chart tests to cover the new label formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd426a07948322a81c2c62091708ee