### PR TITLE
Fix supplier comparison fallbacks

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -2456,14 +2456,32 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
             base_cols.insert(1, "item_id")
         existing_base_cols = [col for col in base_cols if col in mtab.columns]
         base = mtab[existing_base_cols].copy()
+        price_cols_master: List[str] = []
+        for price_col in ("unit_price_material", "unit_price_install"):
+            if price_col in mtab.columns:
+                price_cols_master.append(price_col)
+                base[price_col] = pd.to_numeric(mtab[price_col], errors="coerce")
         if "quantity" in base.columns:
             base["quantity"] = pd.to_numeric(base["quantity"], errors="coerce").fillna(0)
         else:
-            base["quantity"] = 0
+            base["quantity"] = 0.0
         if "total_price" in base.columns:
-            base["total_price"] = pd.to_numeric(base["total_price"], errors="coerce").fillna(0)
+            base["total_price"] = pd.to_numeric(base["total_price"], errors="coerce")
         else:
-            base["total_price"] = 0
+            base["total_price"] = np.nan
+        if price_cols_master:
+            base["unit_price_combined"] = base[price_cols_master].sum(axis=1, min_count=1)
+            computed_master_total = (
+                base["quantity"].fillna(0) * base["unit_price_combined"].fillna(0)
+            )
+            missing_master_total = base["total_price"].isna() | (base["total_price"] == 0)
+            base.loc[missing_master_total, "total_price"] = computed_master_total.loc[
+                missing_master_total
+            ]
+        base["total_price"] = base["total_price"].fillna(0)
+        for temp_col in ["unit_price_combined", *price_cols_master]:
+            if temp_col in base.columns and temp_col not in existing_base_cols:
+                base.drop(columns=temp_col, inplace=True)
         agg_mapping = {
             "code": "first",
             "description": "first",
@@ -2493,10 +2511,11 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
                 ttab = ttab.loc[~summary_mask_supplier].copy()
             ttab = ttab[ttab["description"].astype(str).str.strip() != ""]
             # join by __key__ (manual mapping already built in normalized table)
-            sup_qty_col = "quantity_supplier" if "quantity_supplier" in ttab.columns else "quantity"
+            supplier_mapping = tobj.get("mapping", {}) or {}
             cols = [
                 "__key__",
-                sup_qty_col,
+                "quantity",
+                "quantity_supplier",
                 "unit_price_material",
                 "unit_price_install",
                 "total_price",
@@ -2507,15 +2526,57 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
             existing_cols = [c for c in cols if c in ttab.columns]
             tt = ttab[existing_cols].copy()
             supplier_lookup = _build_join_lookup(ttab)
-            tt[sup_qty_col] = pd.to_numeric(tt[sup_qty_col], errors="coerce")
-            tt["total_price"] = pd.to_numeric(tt["total_price"], errors="coerce").fillna(0)
-            price_cols = [c for c in ["unit_price_material", "unit_price_install"] if c in tt.columns]
-            if price_cols:
-                for col in price_cols:
-                    tt[col] = pd.to_numeric(tt[col], errors="coerce")
-                tt["unit_price_combined"] = tt[price_cols].sum(axis=1, min_count=1)
+            def _numeric(name: str) -> Optional[pd.Series]:
+                if name not in tt.columns:
+                    return None
+                series = pd.to_numeric(tt[name], errors="coerce")
+                tt[name] = series
+                return series
+
+            qty_supplier_series = _numeric("quantity_supplier")
+            supplier_qty_has_data = (
+                qty_supplier_series is not None and qty_supplier_series.notna().any()
+            )
+            if supplier_qty_has_data or "quantity_supplier" in supplier_mapping:
+                sup_qty_col = "quantity_supplier"
+            else:
+                qty_series = _numeric("quantity")
+                sup_qty_col = "quantity"
+                if qty_series is None:
+                    tt[sup_qty_col] = np.nan
+
+            selected_price_cols: List[str] = []
+            for price_col in ("unit_price_material", "unit_price_install"):
+                series = _numeric(price_col)
+                has_data = series is not None and series.notna().any()
+                if has_data or price_col in supplier_mapping:
+                    selected_price_cols.append(price_col)
+                elif price_col in tt.columns:
+                    # Leave column in place for potential debugging but ensure NaNs
+                    tt[price_col] = series if series is not None else np.nan
+            if selected_price_cols:
+                tt["unit_price_combined"] = tt[selected_price_cols].sum(axis=1, min_count=1)
             else:
                 tt["unit_price_combined"] = np.nan
+            total_series = _numeric("total_price")
+            total_has_data = total_series is not None and total_series.notna().any()
+            total_mapped = "total_price" in supplier_mapping or total_has_data
+            if selected_price_cols:
+                computed_total = tt[sup_qty_col].fillna(0) * tt["unit_price_combined"].fillna(0)
+            else:
+                computed_total = pd.Series(np.nan, index=tt.index)
+            if total_mapped and total_has_data:
+                if computed_total.notna().any():
+                    missing_totals = tt["total_price"].isna()
+                    tt.loc[missing_totals, "total_price"] = computed_total.loc[missing_totals]
+            elif computed_total.notna().any():
+                tt["total_price"] = computed_total
+            tt["total_price"] = tt["total_price"].fillna(0)
+            qty_for_unit = tt[sup_qty_col].replace(0, np.nan)
+            derived_unit = tt["total_price"].replace(0, np.nan) / qty_for_unit
+            tt["unit_price_combined"] = tt["unit_price_combined"].where(
+                tt["unit_price_combined"].notna(), derived_unit
+            )
             if "unit" in tt.columns:
                 tt["unit"] = tt["unit"].astype(str).str.strip()
             supplier_totals[sup_name] = float(tt["total_price"].sum())
@@ -2552,7 +2613,12 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
             comp_join_keys = comp["__key__"].astype(str).map(master_join_series)
             tt_grouped["__join_key__"] = tt_grouped["__key__"].astype(str).map(supplier_join_series)
             comp["__join_key__"] = comp_join_keys
-            merge_cols = ["__join_key__", sup_qty_col, "unit_price_combined", "total_price"]
+            qty_merge_col = sup_qty_col
+            if sup_qty_col == "quantity":
+                qty_merge_col = f"__{sup_name}__quantity"
+                if sup_qty_col in tt_grouped.columns:
+                    tt_grouped.rename(columns={sup_qty_col: qty_merge_col}, inplace=True)
+            merge_cols = ["__join_key__", qty_merge_col, "unit_price_combined", "total_price"]
             unit_merge_col: Optional[str] = None
             if "unit" in tt_grouped.columns:
                 unit_merge_col = f"__{sup_name}__unit"
@@ -2561,7 +2627,7 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
             comp = comp.merge(tt_grouped[merge_cols], on="__join_key__", how="left")
             comp.drop(columns=["__join_key__"], inplace=True, errors="ignore")
             rename_map = {
-                sup_qty_col: f"{sup_name} quantity",
+                qty_merge_col: f"{sup_name} quantity",
                 "unit_price_combined": f"{sup_name} unit_price",
                 "total_price": f"{sup_name} total",
             }


### PR DESCRIPTION
## Summary
- recompute master totals from unit prices when provided without explicit totals to stabilize comparisons
- detect and use supplier-specific quantity and price columns only when they contain numeric data, falling back cleanly otherwise
- derive supplier totals and units consistently when only partial inputs are mapped and avoid column collisions during merges

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dea32ee5548322923a4eb7b73e3fec