### PR TITLE
Fix preview scroll sync injection for Streamlit

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -4399,7 +4399,7 @@ with tab_preview:
                 component_key=json.dumps(widget_suffix),
             )
 
-            components.html(script, height=0, key=widget_suffix)
+            components.html(script, height=0)
 
         master_sheet = master_wb.sheets.get(selected_preview_sheet, {})
         master_table = master_sheet.get("table", pd.DataFrame())


### PR DESCRIPTION
## Summary
- remove the unsupported key argument from the preview scroll sync HTML component injection to avoid runtime errors in Streamlit

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3af9b3a4c8322aeedc32243bd736c