### PR TITLE
Include supplier component unit prices in comparison merge

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -3070,6 +3070,8 @@ def compare(master: WorkbookData, bids: Dict[str, WorkbookData], join_mode: str 
                 if sup_qty_col in tt_grouped.columns:
                     tt_grouped.rename(columns={sup_qty_col: qty_merge_col}, inplace=True)
             merge_cols = ["__join_key__", qty_merge_col, "unit_price_combined", "total_price"]
+            if component_averages:
+                merge_cols.extend(component_averages.keys())
             unit_merge_col: Optional[str] = None
             if "unit" in tt_grouped.columns:
                 unit_merge_col = f"__{sup_name}__unit"


### PR DESCRIPTION
## Summary
- ensure supplier component unit price averages are preserved when merging into the comparison table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6446ac4ac832284a9da986c3aea8e