### PR TITLE
Normalize comparison join keys

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -2776,12 +2776,8 @@ def _build_join_lookup(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame(columns=["__item_join__", "__fallback_join__"])
 
     df_local = df.copy()
-    code_series = (
-        df_local.get("code", pd.Series(index=df_local.index, dtype=object))
-        .fillna("")
-        .astype(str)
-        .str.strip()
-    )
+    raw_codes = df_local.get("code", pd.Series(index=df_local.index, dtype=object))
+    code_series = normalize_identifier(raw_codes).fillna("").astype(str).str.strip()
     desc_series = (
         df_local.get("description", pd.Series(index=df_local.index, dtype=object))
         .fillna("")

--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -179,6 +179,41 @@ def test_compare_master_total_with_duplicate_supplier_rows() -> None:
     assert np.isclose(df.attrs["master_total_sum"], 100)
 
 
+def test_compare_normalizes_code_for_join() -> None:
+    master_df = pd.DataFrame(
+        {
+            "code": ["1"],
+            "description": ["Položka"],
+            "unit": ["ks"],
+            "quantity": [1],
+            "total price": [100],
+        }
+    )
+    supplier_df = pd.DataFrame(
+        {
+            "code": [1.0],
+            "description": ["Položka"],
+            "unit": ["ks"],
+            "quantity": [1],
+            "total price": [120],
+        }
+    )
+
+    master_file = make_workbook(master_df)
+    supplier_file = make_workbook(supplier_df)
+
+    master_wb = read_workbook(master_file, limit_sheets=["Sheet1"])
+    supplier_wb = read_workbook(supplier_file, limit_sheets=["Sheet1"])
+
+    apply_master_mapping(master_wb, supplier_wb)
+
+    results = compare(master_wb, {"Bid": supplier_wb})
+    df = results["Sheet1"]
+
+    assert np.isclose(df["Bid total"].iloc[0], 120)
+    assert not df["Bid total"].isna().any()
+
+
 def test_compare_ignores_summary_total_rows() -> None:
     master_raw = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- normalize fallback comparison join keys by reusing normalize_identifier on code values
- add a regression test covering numeric formatting differences between master and supplier codes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64e72dee0832297e6203737401ac0