### PR TITLE
Remove top logo hero from login homepage

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -858,19 +858,13 @@ def inject_login_modern_theme() -> None:
             .stApp {
                 background: #f5f7fa;
             }
-            .hero-panel, .intro-panel, .login-panel, .market-panel {
+            .intro-panel, .login-panel, .market-panel {
                 border-radius: 12px;
                 padding: 1.15rem 1.2rem;
                 border: 1px solid #d9dee8;
                 background: #ffffff;
                 box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
                 margin-bottom: 0.9rem;
-            }
-            .hero-logo {
-                max-width: 460px;
-                width: 100%;
-                height: auto;
-                display: block;
             }
             .intro-text {
                 color: #374151;
@@ -938,10 +932,6 @@ def inject_login_modern_theme() -> None:
 
 def render_login_view(auth_service: AuthService) -> None:
     inject_login_modern_theme()
-    st.markdown('<div class="hero-panel">', unsafe_allow_html=True)
-    st.image("assets/boq_bid_studio_logo.svg", use_container_width=False, width=460)
-    st.markdown("</div>", unsafe_allow_html=True)
-
     st.markdown(
         """
         <div class="intro-panel">


### PR DESCRIPTION
### Motivation
- Simplify the homepage so the initial visible section starts with the existing intro stripe (`BoQ Bid Studio`) by removing the separate top hero/logo block.

### Description
- Removed the inline hero block (`st.image(...)`) and surrounding `.hero-panel` markup from `render_login_view` so the intro panel is the first visible section.
- Cleaned up the injected theme by removing unused `.hero-panel` and `.hero-logo` CSS rules in `inject_login_modern_theme`.

### Testing
- Ran `python -m py_compile boq_bid_studio.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb678730ac8322827b8795def3b405)