### PR TITLE
Zvětšit a vycentrovat název aplikace na přihlašovací stránce

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -892,11 +892,13 @@ def inject_login_modern_theme() -> None:
             }
             .intro-panel {
                 border-radius: 12px;
-                padding: 1.15rem 1.2rem;
+                padding: 1.35rem 1.2rem;
                 border: 1px solid #d9dee8;
                 background: #ffffff;
                 box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
-                margin-bottom: 0.9rem;
+                margin: 0 auto 0.9rem auto;
+                max-width: 860px;
+                text-align: center;
             }
             .st-key-auth_panels_wrap [data-testid="column"] > [data-testid="stVerticalBlock"] {
                 border-radius: 16px;
@@ -910,9 +912,9 @@ def inject_login_modern_theme() -> None:
             }
             .intro-title {
                 color: #111827;
-                font-size: 1.85rem;
+                font-size: clamp(2.4rem, 5vw, 3.4rem);
                 font-weight: 800;
-                line-height: 1.15;
+                line-height: 1.1;
                 margin: 0;
             }
             .intro-subtitle {


### PR DESCRIPTION
### Motivation
- Uživatel požadoval, aby název aplikace „BoQ Bid Studio“ byl vizuálně větší a umístěný uprostřed stránky při zobrazení přihlašovací obrazovky.

### Description
- Upravený `inject_login_modern_theme()` v `boq_bid_studio.py` mění CSS: `.intro-panel` nyní používá `margin: 0 auto`, `max-width: 860px` a `text-align: center` pro horizontální centrování a omezení šířky, `.intro-panel` má mírně větší `padding`, a `.intro-title` má zvětšenou, responsivní velikost písma `font-size: clamp(2.4rem, 5vw, 3.4rem)` s lehce upraveným `line-height`.

### Testing
- Spuštěno `python -m py_compile boq_bid_studio.py` a přeložení proběhlo úspěšně.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1549e3f29883229a83a7b5617911dd)