### PR TITLE
Add logo to intro/login screen

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1001,6 +1001,7 @@ def render_login_view(auth_service: AuthService) -> None:
         """,
         unsafe_allow_html=True,
     )
+    st.image("assets/boq_bid_studio_logo.svg", width=180)
     panels_wrap = st.container(key="auth_panels_wrap")
     left_col, right_col = panels_wrap.columns([2, 3], gap="medium")
 


### PR DESCRIPTION
## Summary
- added intro logo rendering on the authentication landing screen
- display uses existing asset `assets/boq_bid_studio_logo.svg`

## Changes
- `boq_bid_studio.py`
  - in `render_login_view`, added `st.image("assets/boq_bid_studio_logo.svg", width=180)` directly below the intro panel

## Notes
- No runtime tests were executed (static change only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15514d08d88322aea1e7b9c6f298ad)