### PR TITLE
Adjust login branding layout and prefer newly uploaded logo

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -984,6 +984,20 @@ def inject_login_modern_theme() -> None:
             .market-summary-title { color: #334155; font-size: 0.82rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; }
             .market-price { color: #111827; font-size: 1.25rem; font-weight: 700; margin-top: 0.1rem; line-height: 1.2; }
             .market-delta { color: #6b7280; margin-top: 0.1rem; font-size: 0.86rem; font-weight: 600; }
+            .intro-brand-row {
+                display: flex;
+                align-items: center;
+                gap: 0.9rem;
+            }
+            .intro-logo-wrap {
+                background: #ffffff;
+                border-radius: 10px;
+                padding: 0.35rem;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+            }
         </style>
         """,
         unsafe_allow_html=True,
@@ -992,16 +1006,29 @@ def inject_login_modern_theme() -> None:
 
 def render_login_view(auth_service: AuthService) -> None:
     inject_login_modern_theme()
-    st.markdown(
-        """
-        <div class="intro-panel">
-            <div class="intro-title">BoQ Bid Studio</div>
-            <div class="intro-subtitle">Komplexní aplikace pro porovnání nabídek.</div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
-    st.image("assets/boq_bid_studio_logo.svg", width=180)
+    logo_candidates = [
+        "assets/boq_bid_studio_logo_new.png",
+        "assets/boq_bid_studio_logo_new.svg",
+        "assets/boq_bid_studio_logo.svg",
+    ]
+    logo_path = next((path for path in logo_candidates if os.path.exists(path)), logo_candidates[-1])
+
+    brand_left_col, brand_right_col = st.columns([1, 7], gap="small")
+    with brand_left_col:
+        st.markdown('<div class="intro-logo-wrap">', unsafe_allow_html=True)
+        st.image(logo_path, width=90)
+        st.markdown('</div>', unsafe_allow_html=True)
+
+    with brand_right_col:
+        st.markdown(
+            """
+            <div class="intro-panel">
+                <div class="intro-title">BoQ Bid Studio</div>
+                <div class="intro-subtitle">Komplexní aplikace pro porovnání nabídek.</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
     panels_wrap = st.container(key="auth_panels_wrap")
     left_col, right_col = panels_wrap.columns([2, 3], gap="medium")
 


### PR DESCRIPTION
### Motivation
- Umožnit nahrané (nové) logo zobrazit vlevo vedle názvu aplikace a odstranit zobrazení starého historického loga jako primárního prvku. 
- Zajistit, aby měl logo bílý podklad sladěný s pozadím názvu aplikace pro čistý vzhled.
- Preferovat explicitně nově nahraná rozlišení loga před stávajícím souborem, aby nasazení nového loga bylo bez nutnosti mazání starého souboru.

### Description
- Přidána CSS pravidla `.intro-brand-row` a `.intro-logo-wrap` pro umístění a bílý obal loga a mírný stín. 
- Nahrazeno původní jednořádkové zobrazení titulku a loga dvousloupcovým layoutem pomocí `st.columns([1, 7])`, kde vlevo je logo a vpravo titul + podtitul. 
- Přidána logika výběru loga přes `logo_candidates = [...]` a `logo_path = next((path for path in logo_candidates if os.path.exists(path)), logo_candidates[-1])`, která preferuje `assets/boq_bid_studio_logo_new.png`, pak `assets/boq_bid_studio_logo_new.svg` a jako fallback původní `assets/boq_bid_studio_logo.svg`.
- Změny jsou v `boq_bid_studio.py` (login rendering / theme injection) a velikost zobrazeného loga nastavena na `width=90` v obalu s bílým pozadím.

### Testing
- Spuštěno `python -m py_compile boq_bid_studio.py`, které proběhlo úspěšně.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1554f511ec8322afd620d042d2f546)