### PR TITLE
Remove login logo dependency from intro view

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1006,29 +1006,15 @@ def inject_login_modern_theme() -> None:
 
 def render_login_view(auth_service: AuthService) -> None:
     inject_login_modern_theme()
-    logo_candidates = [
-        "assets/boq_bid_studio_logo_new.png",
-        "assets/boq_bid_studio_logo_new.svg",
-        "assets/boq_bid_studio_logo.svg",
-    ]
-    logo_path = next((path for path in logo_candidates if os.path.exists(path)), logo_candidates[-1])
-
-    brand_left_col, brand_right_col = st.columns([1, 7], gap="small")
-    with brand_left_col:
-        st.markdown('<div class="intro-logo-wrap">', unsafe_allow_html=True)
-        st.image(logo_path, width=90)
-        st.markdown('</div>', unsafe_allow_html=True)
-
-    with brand_right_col:
-        st.markdown(
-            """
-            <div class="intro-panel">
-                <div class="intro-title">BoQ Bid Studio</div>
-                <div class="intro-subtitle">Komplexní aplikace pro porovnání nabídek.</div>
-            </div>
-            """,
-            unsafe_allow_html=True,
-        )
+    st.markdown(
+        """
+        <div class="intro-panel">
+            <div class="intro-title">BoQ Bid Studio</div>
+            <div class="intro-subtitle">Komplexní aplikace pro porovnání nabídek.</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
     panels_wrap = st.container(key="auth_panels_wrap")
     left_col, right_col = panels_wrap.columns([2, 3], gap="medium")
 


### PR DESCRIPTION
### Motivation
- The login view attempted to load image assets from `assets/` and crashed when that directory or files were removed, so the UI must not depend on those files at runtime.

### Description
- Removed logo discovery and rendering logic including `logo_candidates`, `os.path.exists(...)` and `st.image(...)`, and kept the textual branding panel (`BoQ Bid Studio` and subtitle) rendered via `st.markdown` so the intro remains branded without image files.

### Testing
- Ran `python -m py_compile boq_bid_studio.py` to ensure the module compiles successfully, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1586a7ea7c8322b8ee11f3cc1f77d0)