### PR TITLE
Add assets directory with .gitkeep

### DIFF
--- a/assets/.gitkeep
+++ b/assets/.gitkeep
@@ -1,0 +1,1 @@
+# Keep assets directory in git


### PR DESCRIPTION
### Motivation
- Provide a tracked `assets` directory for storing static assets and to ensure an otherwise-empty directory is preserved in the repository.

### Description
- Create `assets/` and add `assets/.gitkeep` containing a short comment to keep the directory tracked.

### Testing
- Verified the change with `nl -ba assets/.gitkeep`, `git status --short`, and `git rev-parse --short HEAD`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1587ac8e58832280b25535660f2feb)