### PR TITLE
Unify login and commodity panel title styling

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1056,7 +1056,7 @@ def render_login_view(auth_service: AuthService) -> None:
     left_col, right_col = panels_wrap.columns([2, 3], gap="medium")
 
     with left_col:
-        st.header("Přihlášení do aplikace")
+        st.markdown('<div class="login-panel-main-title">Přihlášení do aplikace</div>', unsafe_allow_html=True)
         st.caption("Pro přístup ke svým projektům se prosím přihlaste.")
         username = st.text_input("Uživatelské jméno nebo e-mail", key="login_username")
         password = st.text_input("Heslo", type="password", key="login_password")


### PR DESCRIPTION
### Motivation
- Sjednotit vizuální styl a horizontální zarovnání nadpisů na přihlašovací stránce tak, aby „Přihlášení do aplikace“ používalo stejnou typografii a odsazení jako „Přehled cen komodit“.

### Description
- V souboru `boq_bid_studio.py` byla zaměněna volání `st.header("Přihlášení do aplikace")` za `st.markdown('<div class="login-panel-main-title">Přihlášení do aplikace</div>', unsafe_allow_html=True)`, aby levý panel používal stejnou CSS třídu `login-panel-main-title` jako pravý panel.

### Testing
- Spuštěno `python -m py_compile boq_bid_studio.py` a kontrola ukázala, že soubor se zkompiloval bez syntaxických chyb.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b4cf0bd88322a9dcdf4c852638b4)