### PR TITLE
Rozšířit horní bílý panel na celou šířku obrazovky

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -906,9 +906,13 @@ def inject_login_modern_theme() -> None:
                 border: 1px solid #d9dee8;
                 background: #ffffff;
                 box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
-                margin: 0 auto 0.9rem auto;
-                max-width: 860px;
+                margin: 0 0 0.9rem 0;
+                width: 100vw;
+                max-width: 100vw;
+                margin-left: calc(50% - 50vw);
+                margin-right: calc(50% - 50vw);
                 text-align: center;
+                box-sizing: border-box;
             }
             .st-key-auth_panels_wrap [data-testid="column"] > [data-testid="stVerticalBlock"] {
                 border-radius: 16px;


### PR DESCRIPTION
### Motivation
- Hlavní název aplikace a logo jsou umístěny v bílém rámečku, který je nyní omezen šířkou obsahu; cílem je, aby tento rámeček vizuálně přesahoval a zabíral celou šířku viewportu. 
- Úprava má zajistit konzistentní vzhled na širokých obrazovkách bez měnění stávajícího vizuálního stylu panelu (barva, zaoblení, stín). 

### Description
- Upraveny styly v `inject_login_modern_theme()` v souboru `boq_bid_studio.py` pro selektor `.intro-panel`. 
- `width` a `max-width` nastaveny na `100vw` a odstraněno pevné `max-width: 860px`, aby panel překročil standardní obsahový kontejner. 
- Přidány `margin-left: calc(50% - 50vw)` a `margin-right: calc(50% - 50vw)` pro roztažení panelu přes celý viewport a `box-sizing: border-box` pro korektní vnitřní odsazení. 

### Testing
- Ověřena syntaktická správnost souboru spuštěním `python -m py_compile boq_bid_studio.py`, které proběhlo úspěšně. 
- Nebyly spuštěny další automatizované unit testy změn konfigurace CSS, viz `python -m py_compile` jako základní kontrola.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b67455508322a12e74177fd28c80)