### PR TITLE
Hide Streamlit top header and remove top padding on homepage

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -896,6 +896,12 @@ def inject_login_modern_theme() -> None:
             .stApp {
                 background: #f5f7fa;
             }
+            header[data-testid="stHeader"] {
+                display: none;
+            }
+            .block-container {
+                padding-top: 0 !important;
+            }
             .st-key-auth_panels_wrap {
                 margin-top: 0.25rem;
                 margin-bottom: 0.5rem;


### PR DESCRIPTION
### Motivation
- Remove the default gray Streamlit header and the extra top spacing so the app starts directly with the white intro panel (logo and app name) on page load.

### Description
- Added CSS in `inject_login_modern_theme()` in `boq_bid_studio.py` to hide `header[data-testid="stHeader"]` and set `.block-container { padding-top: 0 !important; }` so the intro panel sits at the very top of the page.

### Testing
- Ran `python -m py_compile boq_bid_studio.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d9232b48832297f77ac49a1b37ef)