### PR TITLE
Fix login intro bar top offset on homepage

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -899,8 +899,17 @@ def inject_login_modern_theme() -> None:
             header[data-testid="stHeader"] {
                 display: none;
             }
+            [data-testid="stAppViewContainer"] {
+                background: #f5f7fa;
+            }
+            [data-testid="stAppViewContainer"] > .main,
+            [data-testid="stAppViewContainer"] > .main > div {
+                padding-top: 0 !important;
+                margin-top: 0 !important;
+            }
             .block-container {
                 padding-top: 0 !important;
+                margin-top: 0 !important;
             }
             .st-key-auth_panels_wrap {
                 margin-top: 0.25rem;
@@ -913,6 +922,7 @@ def inject_login_modern_theme() -> None:
                 background: #ffffff;
                 box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
                 margin: 0 0 0.9rem 0;
+                margin-top: 0 !important;
                 width: 100vw;
                 max-width: 100vw;
                 margin-left: calc(50% - 50vw);


### PR DESCRIPTION
### Motivation
- Remove the thin gray strip above the homepage login hero so the white intro strip with the logo and app name sits flush at the top of the page.

### Description
- Modify `inject_login_modern_theme()` in `boq_bid_studio.py` to add rules for `[data-testid="stAppViewContainer"]`, zero out top padding/margin for the container and `.main`, reset `.block-container` top spacing, and enforce `margin-top: 0 !important;` on `.intro-panel` so the hero aligns with the page top.

### Testing
- Ran `python -m py_compile boq_bid_studio.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16db1163048322ae57789b747dc672)