### PR TITLE
Move persistent app logo to left and halve its width

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1201,7 +1201,7 @@ def render_must_change_password_view(auth_service: AuthService, user: User) -> N
 
 
 def render_persistent_app_logo() -> None:
-    """Render a persistent app logo in the top-right white content area."""
+    """Render a persistent app logo in the top-left white content area."""
 
     logo_uri = get_inline_image_data_uri("assets/boq_logo_p.png")
     st.markdown(
@@ -1210,7 +1210,7 @@ def render_persistent_app_logo() -> None:
         .app-persistent-logo {{
             position: fixed;
             top: 0.9rem;
-            right: 1.6rem;
+            left: 1.6rem;
             z-index: 1000;
             background: rgba(255, 255, 255, 0.92);
             border-radius: 10px;
@@ -1222,7 +1222,7 @@ def render_persistent_app_logo() -> None:
 
         .app-persistent-logo img {{
             display: block;
-            width: 132px;
+            width: 66px;
             height: auto;
         }}
         </style>


### PR DESCRIPTION
### Motivation
- Adjust the persistent app logo placement and scale to place it on the left side of the UI and reduce its visual prominence by halving its width.

### Description
- Update `render_persistent_app_logo` in `boq_bid_studio.py` to change the docstring and CSS by replacing `right: 1.6rem;` with `left: 1.6rem;` and `width: 132px;` with `width: 66px;` so the logo appears on the top-left at half size.

### Testing
- Run `python -m py_compile boq_bid_studio.py` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18642c37b88322b27928053051767a)