### PR TITLE
Add © 2026 Pavel Turnovsky footer and NOTICE.md

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,3 @@
+© 2026 Pavel Turnovsky. Všechna práva vyhrazena.
+
+Tato aplikace, její zdrojový kód, grafické rozhraní, texty a související dokumentace jsou chráněny autorským právem. Bez předchozího písemného souhlasu autora není dovoleno aplikaci ani její části kopírovat, upravovat, šířit, poskytovat třetím osobám ani používat mimo sjednaný účel.

--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -1200,6 +1200,31 @@ def render_must_change_password_view(auth_service: AuthService, user: User) -> N
 
 
 
+APP_COPYRIGHT_NOTICE = "© 2026 Pavel Turnovsky. Všechna práva vyhrazena."
+
+
+def render_app_footer() -> None:
+    """Render the shared application copyright footer."""
+
+    st.markdown(
+        f"""
+        <style>
+        .app-copyright-footer {{
+            margin-top: 2.5rem;
+            padding: 0.85rem 0 0.25rem 0;
+            border-top: 1px solid #e5e7eb;
+            color: #6b7280;
+            font-size: 0.82rem;
+            line-height: 1.4;
+            text-align: center;
+        }}
+        </style>
+        <div class="app-copyright-footer">{APP_COPYRIGHT_NOTICE}</div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def render_persistent_app_logo() -> None:
     """Render a persistent app logo in the top-left white content area."""
 
@@ -1400,6 +1425,7 @@ def render_auth_router(auth_service: AuthService) -> None:
     else:
         set_auth_view("login")
         render_login_view(auth_service)
+    render_app_footer()
 
 RECAP_CATEGORY_CONFIG = [
     {
@@ -10582,6 +10608,7 @@ if comparison_mode == "Porovnání nabídek bez Master BoQ":
         round_id=round_selection,
         prefill_round_inputs=prefill_round_inputs,
     )
+    render_app_footer()
     st.stop()
 
 stored_master_entries = offer_storage.list_master()
@@ -16533,5 +16560,4 @@ with tab_rounds_v2:
                                 use_container_width=True,
                             )
 
-st.markdown("---")
-st.caption("© 2025 BoQ Bid Studio — MVP. Doporučení: používat jednotné Item ID pro precizní párování.")
+render_app_footer()


### PR DESCRIPTION
### Motivation
- Zobrazit na všech hlavních stránkách aplikace zřetelnou informaci o autorských právech ve formě decentní patičky. 
- Umístit text tak, aby neměnil funkčnost aplikace a byl znovupoužitelný napříč společnými layouty.
- Přidat kořenový právní soubor `NOTICE.md` s požadovaným českým textem a bez vložení žádné open-source licence.

### Description
- Přidán konstantní text `APP_COPYRIGHT_NOTICE = "© 2026 Pavel Turnovsky. Všechna práva vyhrazena."` a nová znovupoužitelná funkce `render_app_footer()` do `boq_bid_studio.py` která vykreslí decentně stylovanou patičku pomocí `st.markdown`.
- Volání `render_app_footer()` vloženo do autentizačního routeru (`render_auth_router`) a do větve „Porovnání nabídek bez Master BoQ“ a nahradilo starý statický caption v dolní části aplikace, aby se footer zobrazoval konzistentně na hlavních obrazovkách.
- Přidán soubor `NOTICE.md` v kořenové složce s požadovaným českým právním textem (rok 2026, autor `Pavel Turnovsky`).
- Prohledáním projektu nebyl nalezen žádný existující `LICENSE` soubor, proto nebyly provedeny žádné změny licencí.

### Testing
- `python -m py_compile boq_bid_studio.py` — úspěch (soubor se zkompiloval bez syntaxních chyb).
- Testovací běh pomocí `streamlit.testing.v1.AppTest` který spustil aplikaci z `boq_bid_studio.py` a ověřil, že text `© 2026 Pavel Turnovsky. Všechna práva vyhrazena.` je vykreslen — úspěch.
- Směrový smoke test spuštěním `streamlit run boq_bid_studio.py --server.headless true --server.port 8501` a HTTP kontrola lokálního rozhraní (HTTP 200) — úspěch.
- `pytest -q` — selhalo během collection s chybou `AttributeError: 'NoneType' object has no attribute 'must_change_password'` protože existující testy importují a vykonávají část aplikace, která očekává přítomnost autentizovaného `current_user`, což je problém v testním nastavení nezávislý na změně patičky.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da3a6c0ac8322932f845f2c416703)