### PR TITLE
Handle PyArrow-backed string arrays in numeric coercion and add tests

### DIFF
--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -5319,9 +5319,17 @@ def coerce_numeric(s: pd.Series) -> pd.Series:
     if s.empty:
         return pd.to_numeric(s, errors="coerce")
 
-    cleaned = s.astype(str)
+    # Some Streamlit Cloud/Pandas combinations keep imported Excel/CSV text in
+    # Arrow-backed string arrays. PyArrow's regex engine does not support every
+    # escape sequence accepted by Python's ``re`` module, so normalizing numeric
+    # text via ``Series.str.replace(..., regex=True)`` can raise
+    # ``pyarrow.lib.ArrowInvalid`` before conversion. Force an object-backed
+    # Series of regular Python strings first so every cleanup step below uses
+    # Pandas/Python string handling consistently.
+    cleaned = pd.Series(s.to_numpy(dtype=object), index=s.index, dtype="object")
+    cleaned = cleaned.where(cleaned.notna(), "").map(str)
+    cleaned = cleaned.str.replace("\u00A0", "", regex=False)
     cleaned = cleaned.str.replace(r"\s+", "", regex=True)
-    cleaned = cleaned.str.replace(r"\u00A0", "", regex=True)
     cleaned = cleaned.str.replace(r"(?i)(czk|kč|eur|€|usd|\$|gbp|£)", "", regex=True)
     cleaned = cleaned.str.replace(r"[+-]$", "", regex=True)
     cleaned = cleaned.str.replace(r"[^0-9,\.\-+]", "", regex=True)

--- a/tests/test_bid_loading.py
+++ b/tests/test_bid_loading.py
@@ -1,3 +1,4 @@
+import importlib.util
 import io
 import os
 import sys
@@ -14,7 +15,7 @@ sys.path.append(str(ROOT))
 from workbook import WorkbookData
 
 # Load only helper functions from boq_bid_studio without running Streamlit app
-module_code = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+module_code = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Auth & Session -------------")[0]
 module = types.ModuleType("boq_bid_helpers")
 exec(module_code, module.__dict__)
 module.try_autodetect_mapping = module.try_autodetect_mapping.__wrapped__
@@ -25,6 +26,7 @@ compare = module.compare
 validate_totals = module.validate_totals
 overview_comparison = module.overview_comparison
 supplier_only_qa_checks = module.supplier_only_qa_checks
+ARROW_STRING_DTYPE = "string[pyarrow]" if importlib.util.find_spec("pyarrow") else "string"
 
 
 def make_workbook(df: pd.DataFrame) -> io.BytesIO:
@@ -105,6 +107,55 @@ def test_rename_value_columns_adds_percent_diff() -> None:
     assert diff_col in renamed.columns
     value = renamed.loc[0, diff_col]
     assert pytest.approx(value, rel=1e-5) == 20.0
+
+
+
+def test_coerce_numeric_handles_arrow_strings_with_nbsp() -> None:
+    values = pd.Series(
+        [
+            "1 234,56",
+            "1\u00A0234,56",
+            "1.234,56",
+            "1,234.56",
+            "Kč 1 234,56",
+            "",
+            np.nan,
+        ],
+        dtype=ARROW_STRING_DTYPE,
+    )
+
+    result = module.coerce_numeric(values)
+
+    assert result.iloc[:5].tolist() == pytest.approx([1234.56] * 5)
+    assert result.iloc[5:].isna().all()
+
+
+def test_build_normalized_table_handles_arrow_numeric_text() -> None:
+    df = pd.DataFrame(
+        {
+            "code": pd.Series(["A"], dtype=ARROW_STRING_DTYPE),
+            "description": ["Položka"],
+            "item_id": ["ROW-1"],
+            "unit": ["ks"],
+            "quantity": pd.Series(["1\u00A0234,56"], dtype=ARROW_STRING_DTYPE),
+            "quantity_supplier": ["2\u00A0345,67"],
+            "unit_price_material": ["Kč 3\u00A0456,78"],
+            "unit_price_install": ["4 567,89 Kč"],
+            "total_price": ["5.678,90"],
+            "summary_total": ["6,789.01"],
+        }
+    )
+    mapping = {name: idx for idx, name in enumerate(df.columns)}
+
+    table = module.build_normalized_table(df, mapping, preserve_summary_totals=True)
+
+    assert table.loc[0, "quantity"] == pytest.approx(1234.56)
+    assert table.loc[0, "quantity_supplier"] == pytest.approx(2345.67)
+    assert table.loc[0, "unit_price_material"] == pytest.approx(3456.78)
+    assert table.loc[0, "unit_price_install"] == pytest.approx(4567.89)
+    assert table.loc[0, "total_price"] == pytest.approx(5678.90)
+    assert table.loc[0, "summary_total"] == pytest.approx(6789.01)
+
 
 def test_multiple_bid_loading() -> None:
     master_df = pd.DataFrame({

--- a/tests/test_description_comparison.py
+++ b/tests/test_description_comparison.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
 MODULE_CODE = (
     ROOT / "boq_bid_studio.py"
-).read_text().split("# ------------- Sidebar Inputs -------------")[0]
+).read_text().split("# ------------- Auth & Session -------------")[0]
 helpers_module = types.ModuleType("description_helpers")
 exec(MODULE_CODE, helpers_module.__dict__)
 

--- a/tests/test_fingerprint_normalization.py
+++ b/tests/test_fingerprint_normalization.py
@@ -6,7 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
 module_code = (ROOT / "boq_bid_studio.py").read_text().split(
-    "# ------------- Sidebar Inputs -------------"
+    "# ------------- Auth & Session -------------"
 )[0]
 module = types.ModuleType("boq_bid_helpers")
 module.ENGINE_VERSION = "test"

--- a/tests/test_offer_storage.py
+++ b/tests/test_offer_storage.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
 os.environ["BOQ_BID_TEST_MODE"] = "1"
-MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Auth & Session -------------")[0]
 module = types.ModuleType("boq_bid_helpers_storage")
 exec(MODULE_CODE, module.__dict__)
 

--- a/tests/test_outline_metadata.py
+++ b/tests/test_outline_metadata.py
@@ -9,7 +9,7 @@ from core.excel_outline import build_outline_nodes
 # Reuse helper module without triggering full Streamlit app
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
-module_code = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+module_code = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Auth & Session -------------")[0]
 outline_module = types.ModuleType("outline_helpers")
 exec(module_code, outline_module.__dict__)
 _attach_outline_metadata = outline_module._attach_outline_metadata

--- a/tests/test_recap_chart.py
+++ b/tests/test_recap_chart.py
@@ -7,7 +7,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(ROOT))
-MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Sidebar Inputs -------------")[0]
+MODULE_CODE = (ROOT / "boq_bid_studio.py").read_text().split("# ------------- Auth & Session -------------")[0]
 module = types.ModuleType("boq_bid_helpers_recap")
 exec(MODULE_CODE, module.__dict__)
 


### PR DESCRIPTION
### Motivation

- Avoid `pyarrow.lib.ArrowInvalid` errors when cleaning numeric text stored in Arrow-backed string arrays by normalizing to regular Python strings first.  
- Ensure NBSPs and currency markers are stripped correctly and add tests that cover Arrow `string` dtype input.  
- Update test helpers extraction to stop splitting the module at the Streamlit sidebar marker and instead cut at the Auth & Session section so tests can import helper code without launching the app.

### Description

- Change `coerce_numeric` to force an object-backed `Series` by creating `pd.Series(s.to_numpy(dtype=object), index=s.index, dtype="object")`, then normalize via `map(str)` to avoid PyArrow regex limitations.  
- Reorder/adjust cleaning steps to replace NBSP (`\u00A0`) using `regex=False` and perform subsequent regex cleans and currency-symbol stripping as before.  
- Update multiple tests to split the source file at `# ------------- Auth & Session -------------` when extracting helper code so the Streamlit app isn't executed.  
- Add `ARROW_STRING_DTYPE` detection in tests to use `string[pyarrow]` when `pyarrow` is available.  
- Add tests `test_coerce_numeric_handles_arrow_strings_with_nbsp` and `test_build_normalized_table_handles_arrow_numeric_text` to validate numeric parsing for Arrow-backed strings with NBSPs and various currency/format permutations.

### Testing

- Ran unit tests including the new Arrow-string coverage tests with `pytest`; the new tests `test_coerce_numeric_handles_arrow_strings_with_nbsp` and `test_build_normalized_table_handles_arrow_numeric_text` passed.  
- Existing test files were adjusted to import helper code safely and the modified test suite passed under the same `pytest` run.  
- No automated tests failed after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2137fa2f308322849f09eedc04ca84)