### PR TITLE
Make storage directory configurable, add Railway deployment config and docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Aplikace podporuje načtení a zobrazení skupin řádků/sloupců (Excel outlin
 * Outline u souborů **.xls** (BIFF) není podporován.
 * Export s outline vytváří nový sešit bez maker (XLSX). Pro soubory XLSM se makra nepřenášejí.
 * Panel Outline je aktuálně dostupný pouze na záložce **🧾 Kontrola dat**.
+
+## Nasazení na Railway
+
+Postup pro nasazení aplikace, persistentní Railway Volume a propojení domény
+`www.boq-studio.cz` spravované u FORPSI je popsán v
+[`docs/railway_deployment.md`](docs/railway_deployment.md).

--- a/app_config.py
+++ b/app_config.py
@@ -1,0 +1,22 @@
+"""Shared runtime configuration for local and hosted deployments."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_storage_dir() -> Path:
+    """Return the persistent application storage directory.
+
+    Hosted deployments can set ``BOQ_STORAGE_DIR`` to a mounted persistent
+    volume. Local development keeps the existing per-user default.
+    """
+
+    configured_dir = os.getenv("BOQ_STORAGE_DIR")
+    if configured_dir:
+        return Path(configured_dir).expanduser()
+    return Path.home() / ".boq_bid_studio"
+
+
+DEFAULT_STORAGE_DIR = get_storage_dir()

--- a/auth_user_store.py
+++ b/auth_user_store.py
@@ -4,9 +4,8 @@ import json
 from pathlib import Path
 from typing import Iterable, List, Optional
 
+from app_config import DEFAULT_STORAGE_DIR
 from auth_models import PasswordResetToken, User, utc_now_iso
-
-DEFAULT_STORAGE_DIR = Path.home() / ".boq_bid_studio"
 
 
 class AuthUserStore:

--- a/boq_bid_studio.py
+++ b/boq_bid_studio.py
@@ -30,6 +30,7 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 import streamlit.components.v1 as components
+from app_config import DEFAULT_STORAGE_DIR
 from auth_models import User
 from auth_service import AuthService
 from reportlab.lib import colors
@@ -600,7 +601,6 @@ EXCHANGE_RATE_WIDGET_KEYS = {
     "recap": "recap_exchange_rate",
 }
 RESERVED_ALIAS_NAMES = {"Master", "LOWEST"}
-DEFAULT_STORAGE_DIR = Path.home() / ".boq_bid_studio"
 SCHEMA_VERSION = "1.0"
 ENGINE_VERSION = "0.4"
 SESSION_TIMEOUT_SECONDS = 30 * 60

--- a/docs/railway_deployment.md
+++ b/docs/railway_deployment.md
@@ -1,0 +1,126 @@
+# Nasazení BoQ Bid Studio na Railway a propojení domény FORPSI
+
+Tento návod používá jako hlavní adresu aplikace `https://www.boq-studio.cz`.
+Kořenová doména `https://boq-studio.cz` se na ni přesměruje.
+
+## 1. Nasazení služby na Railway
+
+1. V Railway vytvořte projekt a propojte jej s GitHub repozitářem aplikace.
+2. Railway použije soubor `railway.json`. Ten spustí Streamlit na adrese
+   `0.0.0.0` a na portu z proměnné `$PORT`, kterou Railway doplní automaticky.
+3. V **Service → Settings → Networking → Public Networking** zvolte
+   **Generate Domain**.
+4. Otevřete vygenerovanou adresu `*.up.railway.app` a ověřte, že aplikace
+   funguje ještě před nastavováním vlastní domény.
+5. Pokud deployment neprojde, zkontrolujte v Railway **Deploy Logs**, zda
+   Streamlit nastartoval a neukončil se chybou.
+
+Proměnnou `PORT` v Railway ručně nenastavujte, pokud k tomu nemáte zvláštní
+důvod. Railway ji službě poskytuje a používá ji také pro healthcheck.
+
+## 2. Trvalé úložiště
+
+Aplikace ukládá uživatele, projekty a nahrané soubory na disk. Bez Railway
+Volume by se tato data mohla při novém deploymentu ztratit.
+
+1. V Railway přidejte ke službě **Volume**.
+2. Nastavte mount path například na `/data`.
+3. V **Service → Variables** přidejte:
+
+   ```text
+   BOQ_STORAGE_DIR=/data/boq_bid_studio
+   ```
+
+4. Proveďte redeploy.
+5. Vytvořte testovací projekt, proveďte další redeploy a ověřte, že projekt
+   zůstal dostupný.
+
+Pro lokální spuštění není proměnná povinná. Aplikace nadále používá výchozí
+adresář `~/.boq_bid_studio`.
+
+## 3. Přidání `www.boq-studio.cz` v Railway
+
+1. Otevřete **Service → Settings → Networking → Public Networking**.
+2. Klikněte na **Custom Domain** a zadejte přesně:
+
+   ```text
+   www.boq-studio.cz
+   ```
+
+3. Railway zobrazí cílovou CNAME adresu, například
+   `xxxxxxxx.up.railway.app`. Zkopírujte přesnou hodnotu z Railway; příklad
+   z tohoto návodu nepoužívejte.
+4. Doménu zatím v Railway nemažte. Po správném DNS nastavení ji Railway ověří
+   a automaticky pro ni vystaví TLS/HTTPS certifikát.
+
+## 4. Nastavení DNS ve FORPSI
+
+V administraci FORPSI otevřete **Domény → boq-studio.cz → Editace DNS
+záznamů**. Pokud tato volba není dostupná, doména používá jiné nameservery a
+záznam je nutné upravit u jejich skutečného správce.
+
+Pro subdoménu `www` nastavte:
+
+| Název | Typ | Hodnota |
+|---|---|---|
+| `www` / `www.boq-studio.cz` | `CNAME` | přesná hodnota z Railway, např. `xxxxxxxx.up.railway.app` |
+
+Při změně:
+
+- odstraňte existující `A` nebo `AAAA` záznam pro **stejný název `www`**;
+  CNAME nesmí být současně s jiným záznamem stejného názvu,
+- cílovou Railway adresu zadejte bez `https://`, bez cesty a podle instrukcí
+  FORPSI bez tečky na konci,
+- nemažte MX/TXT záznamy používané pro e-mail,
+- vyčkejte na propagaci DNS; Railway uvádí, že změna může celosvětově trvat
+  až 72 hodin.
+
+Správný výsledek lze ověřit například:
+
+```bash
+dig +short www.boq-studio.cz CNAME
+curl -I https://www.boq-studio.cz
+```
+
+První příkaz má vrátit Railway CNAME a druhý platnou HTTP odpověď přes HTTPS.
+
+## 5. Kořenová doména `boq-studio.cz`
+
+Běžný CNAME nelze bezpečně použít na kořeni DNS zóny vedle povinných záznamů.
+Nejjednodušší varianta při správě DNS u FORPSI je proto:
+
+1. ponechat aplikaci na `www.boq-studio.cz`,
+2. u FORPSI objednat/nastavit službu **Redirect**,
+3. nastavit trvalé přesměrování HTTP 301 z `boq-studio.cz` na:
+
+   ```text
+   https://www.boq-studio.cz
+   ```
+
+Pokud nechcete používat placený Redirect od FORPSI, lze DNS přesunout ke
+správci podporujícímu `ALIAS`/CNAME flattening pro kořenovou doménu a přidat
+v Railway také `boq-studio.cz`. Při přesunu DNS je nutné přenést i všechny
+MX, TXT a další používané záznamy.
+
+## 6. Diagnostika
+
+Postupujte vždy v tomto pořadí:
+
+1. Deployment v Railway je zelený.
+2. Funguje vygenerovaná Railway adresa `*.up.railway.app`.
+3. `dig +short www.boq-studio.cz CNAME` vrací hodnotu přidělenou Railway.
+4. Railway ukazuje zelené ověření u přesné domény `www.boq-studio.cz`.
+5. Funguje `https://www.boq-studio.cz`.
+6. Nakonec funguje přesměrování z `https://boq-studio.cz`.
+
+Pokud nefunguje už krok 2, nejde o problém DNS/FORPSI. Zkontrolujte Railway
+Deploy Logs. Pokud funguje krok 2, ale ne krok 3, je problém v DNS nastavení.
+Pokud funguje krok 3 a Railway doménu ověřilo, ale HTTPS ještě nefunguje,
+vyčkejte na vystavení certifikátu a propagaci DNS.
+
+## Oficiální návody
+
+- Railway: <https://docs.railway.com/deploy/exposing-your-app>
+- Railway healthchecks a proměnná `PORT`: <https://docs.railway.com/reference/healthchecks>
+- FORPSI nastavení DNS: <https://support.forpsi.com/kb/a4183/nastaveni-dns-zaznamu.aspx>
+- FORPSI Redirect: <https://support.forpsi.com/kb/a4680/redirect-presmerovani-domeny.aspx>

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS"
+  },
+  "deploy": {
+    "startCommand": "streamlit run boq_bid_studio.py --server.address 0.0.0.0 --server.port $PORT --server.headless true",
+    "healthcheckPath": "/",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+
+from app_config import get_storage_dir
+
+
+def test_storage_dir_uses_local_default(monkeypatch):
+    monkeypatch.delenv("BOQ_STORAGE_DIR", raising=False)
+
+    assert get_storage_dir() == Path.home() / ".boq_bid_studio"
+
+
+def test_storage_dir_uses_environment_override(monkeypatch):
+    monkeypatch.setenv("BOQ_STORAGE_DIR", "~/boq-data")
+
+    assert get_storage_dir() == Path.home() / "boq-data"


### PR DESCRIPTION
### Motivation

- Make the application's persistent storage directory configurable for hosted deployments (Railway) instead of using a hardcoded per-user path. 
- Provide deployment guidance and configuration for running the app on Railway with a persistent volume and custom domain. 

### Description

- Add `app_config.py` exposing `get_storage_dir()` and `DEFAULT_STORAGE_DIR` which honor the `BOQ_STORAGE_DIR` environment variable. 
- Switch modules to use the centralized `DEFAULT_STORAGE_DIR` by updating `auth_user_store.py` and `boq_bid_studio.py` to import from `app_config.py`. 
- Add Railway orchestration files and docs by introducing `railway.json` and `docs/railway_deployment.md`, and update `README.md` with a short note linking to the Railway deployment guide. 
- Add unit tests in `tests/test_app_config.py` that verify the default storage path and the environment override behavior of `get_storage_dir()`. 

### Testing

- Ran the new unit tests with `pytest tests/test_app_config.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297d1a6dfc8322ab823ab3a0f17e5b)